### PR TITLE
Make some server stuff asynchronous

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ Cargo.lock
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # Added by cargo
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -23,13 +23,9 @@ unsize.workspace = true
 base64 = "0.22.1"
 bitflags = { version = "2.6.0", features = ["bytemuck"] }
 crossbeam-channel = "0.5.13"
-once_map = { version = "0.4.21", features = ["serde"] }
-ordered-float = "4.5.0"
-papaya = "0.1.6"
 rand_distr = "0.4.3"
 rand_xoshiro = "0.6.0"
 redb = { version = "2.2.0", features = ["logging"] }
-rayon = "1.10.0"
 wasm-timer = "0.2.5"
 
 [dev-dependencies]

--- a/server/src/chunk.rs
+++ b/server/src/chunk.rs
@@ -4,16 +4,18 @@ use crate::terrain::climate::ClimateCell;
 use crate::utils::database::Database;
 use crate::utils::mesh::*;
 use bevy::prelude::*;
-use bevy::utils::tracing::Span;
-use bevy::utils::HashMap;
+use bevy::tasks::AsyncComputeTaskPool;
+use bevy::utils::tracing::{Instrument, Span};
+use bevy::utils::{ConditionalSend, HashMap};
+use crossbeam_channel::{Receiver, Sender};
 use factor_common::cell::corners_of;
 use factor_common::coords::{get_absolute, get_relative, LonLat};
 use factor_common::data::{ChunkId, ChunkInterest, PlayerId};
 use factor_common::healpix;
 use rand::prelude::*;
-use rayon::prelude::*;
-use redb::{ReadableTable, Table};
+use redb::{ReadableTable, Table, WriteTransaction};
 use serde::{Deserialize, Serialize};
+use std::future::Future;
 use std::io;
 use std::num::NonZeroUsize;
 use std::ops::{Add, Mul};
@@ -261,103 +263,141 @@ pub fn unload_chunks(
     }
 }
 
+/// Channels to interact with the chunkloading thread
+#[derive(Debug, Resource)]
+pub struct AsyncChunks {
+    pub send: Sender<(u64, ChunkData)>,
+    pub recv: Receiver<(u64, ChunkData)>,
+}
+impl Default for AsyncChunks {
+    fn default() -> Self {
+        let (send, recv) = crossbeam_channel::bounded(512);
+        Self { send, recv }
+    }
+}
+
 pub fn load_chunks(
     commands: ParallelCommands,
     cfg: Res<WorldConfig>,
     db: Res<Database>,
     mut to_load: EventReader<ChunkRequest>,
-    mut queue: Local<
-        Option<(
-            crossbeam_channel::Sender<u64>,
-            crossbeam_channel::Receiver<u64>,
-        )>,
-    >,
+    mut channels: Local<Option<(Sender<(u64, bool)>, Receiver<(u64, ChunkData)>)>>,
 ) {
-    use std::time::Duration;
-    use wasm_timer::Instant;
-    const TIMEOUT: Duration = Duration::from_millis(100);
-    let span = Span::current();
-    let (tx, rx) = queue.get_or_insert_with(crossbeam_channel::unbounded);
-    let start = Instant::now();
-    let has_time = rx
-        .try_iter()
-        .par_bridge()
-        .try_for_each(|id| {
-            let _guard = span.enter();
-            let step = Instant::now();
-            load_chunk(id, &commands, &cfg, &db);
-            debug!(id, time = ?step.elapsed(), "Loaded chunk");
-            (start.elapsed() < TIMEOUT).then_some(())
-        })
-        .is_some();
-    if has_time {
-        to_load.par_read().for_each(|&ChunkRequest { id }| {
-            if start.elapsed() < TIMEOUT {
-                let _guard = span.enter();
-                let step = Instant::now();
-                load_chunk(id, &commands, &cfg, &db);
-                debug!(id, time = ?step.elapsed(), "Loaded chunk");
-            } else if let Err(err) = tx.send(id) {
-                error!(%err, "Error queuing chunk load request");
-            }
-        });
-    } else {
-        warn!(
-            queued = rx.len(),
-            new = to_load.len(),
-            "Chunk loading behind"
-        );
-        to_load.par_read().for_each(|req| {
-            if let Err(err) = tx.send(req.id) {
-                error!(%err, "Error queuing chunk load request");
-            }
-        });
-    }
-}
+    if let Some((send, recv)) = &*channels {
+        for (id, data) in recv.try_iter() {
+            commands.command_scope(|mut commands| {
+                let entity = commands.spawn((ChunkId(id), data.surface)).id();
+                commands.trigger(ChunkLoaded { id, entity });
+            });
+        }
+        match recv.try_recv() {
+            Ok((id, data)) => {
+                // whoops
+                commands.command_scope(|mut commands| {
+                    let entity = commands.spawn((ChunkId(id), data.surface)).id();
+                    commands.trigger(ChunkLoaded { id, entity });
+                });
 
-pub fn load_chunk(id: u64, commands: &ParallelCommands, cfg: &WorldConfig, db: &Database) {
-    let res: Result<(), redb::Error> = try {
-        let txn = db.begin_read()?;
-        match txn.open_table(CHUNKS) {
-            Ok(table) => {
-                if let Some(chunk) = table.get(id)? {
-                    if let Some(data) = chunk.value() {
-                        commands.command_scope(|mut commands| {
-                            let entity = commands.spawn((ChunkId(id), data.surface)).id();
-                            commands.trigger(ChunkLoaded { id, entity });
-                        });
-                        drop(table);
-                        txn.close()?;
-                        return;
+                to_load.read().for_each(|&ChunkRequest { id }| {
+                    if let Err(_err) = send.send((id, true)) {
+                        error!("Channel is somehow closed?");
+                    }
+                });
+            }
+            Err(crossbeam_channel::TryRecvError::Empty) => {
+                to_load.read().for_each(|&ChunkRequest { id }| {
+                    if let Err(_err) = send.send((id, true)) {
+                        error!("Channel is somehow closed?");
+                    }
+                })
+            }
+            Err(crossbeam_channel::TryRecvError::Disconnected) => *channels = None,
+        }
+    }
+    let mut new_stuff = None;
+    to_load.read().for_each(|&ChunkRequest { id }| {
+        let start = wasm_timer::Instant::now();
+        let res: Result<(), redb::Error> = try {
+            let txn = db.begin_read()?;
+            match txn.open_table(CHUNKS) {
+                Ok(table) => {
+                    if let Some(chunk) = table.get(id)? {
+                        if let Some(data) = chunk.value() {
+                            commands.command_scope(|mut commands| {
+                                let entity = commands.spawn((ChunkId(id), data.surface)).id();
+                                commands.trigger(ChunkLoaded { id, entity });
+                            });
+                            drop(table);
+                            txn.close()?;
+                            debug!(id, time = ?start.elapsed(), "Loaded chunk");
+                            return;
+                        }
                     }
                 }
+                Err(redb::TableError::TableDoesNotExist(_)) => {}
+                Err(err) => Err(err)?,
             }
-            Err(redb::TableError::TableDoesNotExist(_)) => {}
-            Err(err) => Err(err)?,
+            txn.close()?;
+        };
+        if let Err(err) = res {
+            error!(id, %err, "Error loading chunk");
         }
-        txn.close()?;
-        let txn = db.begin_write()?;
-        let mut table = txn.open_table(CHUNKS)?;
-        let surface = setup_chunk(
-            cfg,
-            id,
-            &mut txn.open_table(TERRAIN)?,
-            &mut txn.open_table(HIGH_VALUE_NOISE)?,
-            &mut txn.open_table(HIGH_GRAD_NOISE)?,
-        )?;
-        let opt_data = Some(ChunkData { surface });
-        table.insert(id, &opt_data)?;
-        drop(table);
-        txn.commit()?;
-        commands.command_scope(|mut commands| {
-            let entity = commands
-                .spawn((ChunkId(id), opt_data.unwrap().surface))
-                .id();
-            commands.trigger(ChunkLoaded { id, entity });
+        let (send, _) = channels.get_or_insert_with(|| {
+            let (tx1, rx1) = crossbeam_channel::bounded(512);
+            let (tx2, rx2) = crossbeam_channel::bounded(16);
+            new_stuff = Some((rx1, tx2));
+            (tx1, rx2)
         });
-    };
-    if let Err(err) = res {
-        error!(id, %err, "Error loading chunk");
+        if let Err(_err) = send.send((id, false)) {
+            error!("Channel is somehow closed?");
+        }
+    });
+    if let Some((to_load, sender)) = new_stuff {
+        match db.begin_write() {
+            Ok(txn) => {
+                let config = cfg.clone();
+                AsyncComputeTaskPool::get()
+                    .spawn(
+                        async move {
+                            let _: Result<(), redb::Error> = try {
+                                loop {
+                                    match to_load.try_recv() {
+                                        Ok((id, check_load)) => {
+                                            let start = wasm_timer::Instant::now();
+                                            let surface = setup_chunk(&config, id, &txn)?.await?;
+                                            let mut table = txn.open_table(CHUNKS)?;
+                                            if check_load {
+                                                if let Some(chunk) = table.get(id)? {
+                                                    if let Some(data) = chunk.value() {
+                                                        if let Err(_err) = sender.send((id, data)) {
+                                                            error!("Channel is somehow closed?");
+                                                        }
+                                                        debug!(id, time = ?start.elapsed(), "Loaded chunk");
+                                                        continue;
+                                                    }
+                                                }
+                                            }
+                                            let opt_data = Some(ChunkData { surface });
+                                            table.insert(id, &opt_data)?;
+                                            drop(table);
+                                            if let Err(_err) = sender.send((id, opt_data.unwrap()))
+                                            {
+                                                error!("Channel is somehow closed?");
+                                            }
+                                            debug!(id, time = ?start.elapsed(), "Loaded chunk");
+                                        }
+                                        Err(crossbeam_channel::TryRecvError::Empty) => {}
+                                        Err(crossbeam_channel::TryRecvError::Disconnected) => break,
+                                    }
+                                }
+                            };
+                        }
+                        .instrument(Span::current()),
+                    )
+                    .detach();
+            }
+            Err(err) => error!(%err, "Error starting write transaction"),
+        }
     }
 }
 
@@ -463,13 +503,14 @@ fn get_height(
     Ok(height)
 }
 
-fn setup_chunk(
-    config: &WorldConfig,
+fn setup_chunk<'txn>(
+    config: &'txn WorldConfig,
     hash: u64,
-    terrain: &mut Table<u64, ClimateCell>,
-    high_value: &mut Table<NoiseLocation, f32>,
-    high_grad: &mut Table<NoiseLocation, [f32; 2]>,
-) -> Result<MeshData, redb::Error> {
+    txn: &'txn WriteTransaction,
+) -> Result<
+    impl Future<Output = Result<MeshData, redb::Error>> + ConditionalSend + 'txn,
+    redb::TableError,
+> {
     use factor_common::healpix::nested::zordercurve::*;
     let zoc = get_zoc(4);
     let base_hash = hash >> 8;
@@ -489,17 +530,23 @@ fn setup_chunk(
         let j = j as f32 * 0.5;
         bilinear(i, j, base_corners)
     });
+    let mut terrain = txn.open_table(TERRAIN)?;
+    let mut high_value = txn.open_table(HIGH_VALUE_NOISE)?;
+    let mut high_grad = txn.open_table(HIGH_GRAD_NOISE)?;
     let center = healpix::Layer::new(12).center(base_hash);
-    let surface = try_mesh_quad(chunk_corners, 64, |MeshPoint { abs, .. }| {
-        get_height(
-            config,
-            get_absolute(center, abs.into()),
-            terrain,
-            high_value,
-            high_grad,
-        )
-    })?;
-    Ok(surface)
+    Ok(async_try_mesh_quad(
+        chunk_corners,
+        64,
+        move |MeshPoint { abs, .. }| {
+            get_height(
+                config,
+                get_absolute(center, abs.into()),
+                &mut terrain,
+                &mut high_value,
+                &mut high_grad,
+            )
+        },
+    ))
 }
 
 fn bilinear<T: Mul<f32, Output = T> + Add<Output = T>>(i: f32, j: f32, verts: [T; 4]) -> T {

--- a/server/src/chunk.rs
+++ b/server/src/chunk.rs
@@ -263,19 +263,6 @@ pub fn unload_chunks(
     }
 }
 
-/// Channels to interact with the chunkloading thread
-#[derive(Debug, Resource)]
-pub struct AsyncChunks {
-    pub send: Sender<(u64, ChunkData)>,
-    pub recv: Receiver<(u64, ChunkData)>,
-}
-impl Default for AsyncChunks {
-    fn default() -> Self {
-        let (send, recv) = crossbeam_channel::bounded(512);
-        Self { send, recv }
-    }
-}
-
 /// Self-referential type for my receiver mess
 pub struct ReceiverState {
     to_load: Receiver<(u64, bool)>,

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -60,7 +60,6 @@ impl Plugin for ServerPlugin {
             .add_event::<chunk::ChunkLoaded>()
             .add_event::<chunk::UnloadChunk>()
             .add_event::<chunk::InterestChanged>()
-            .init_resource::<chunk::AsyncChunks>()
             .insert_resource(ClimateRunning(false))
             .insert_resource(ServerSystems {
                 setup_terrain,

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -60,6 +60,7 @@ impl Plugin for ServerPlugin {
             .add_event::<chunk::ChunkLoaded>()
             .add_event::<chunk::UnloadChunk>()
             .add_event::<chunk::InterestChanged>()
+            .init_resource::<chunk::AsyncChunks>()
             .insert_resource(ClimateRunning(false))
             .insert_resource(ServerSystems {
                 setup_terrain,

--- a/server/src/terrain/bevy.rs
+++ b/server/src/terrain/bevy.rs
@@ -231,7 +231,7 @@ pub(crate) fn setup_tect(
     let ClimatePhase::TectSetup(mut step) = **state else {
         unreachable!()
     };
-    if step == 0 {
+    if step == 0 && channel.is_none() {
         debug!("Beginning tectonics setup");
     }
     trace!(step, "Tectonics setup");
@@ -340,7 +340,7 @@ pub(crate) fn run_climate(
     let ClimatePhase::ClimateStep(step) = **state else {
         unreachable!()
     };
-    if step == 0 {
+    if step == 0 && channel.is_none() {
         debug!("Beginning climate simulation");
     }
     if let Some(rx) = &mut *channel {

--- a/server/src/terrain/bevy.rs
+++ b/server/src/terrain/bevy.rs
@@ -7,6 +7,8 @@ use crate::tables::{DataEntry, MISC_DATA, TERRAIN};
 use crate::utils::database::*;
 use crate::utils::db_value::ErasedValue;
 use bevy::prelude::*;
+use bevy::tasks::AsyncComputeTaskPool;
+use crossbeam_channel::Receiver;
 use factor_common::healpix;
 use factor_common::util::UpdateStates;
 use rand::prelude::*;
@@ -142,7 +144,7 @@ pub struct RunningTectonics;
 #[source(ClimatePhase = ClimatePhase::ClimateStep(_))]
 pub struct RunningClimate;
 
-#[derive(Debug, Resource)]
+#[derive(Debug, Clone, Resource)]
 pub(crate) struct ClimateInit {
     rng: RandSource,
 }
@@ -224,20 +226,48 @@ pub(crate) fn setup_tect(
     config: Res<WorldConfig>,
     state: Res<State<ClimatePhase>>,
     mut next_state: ResMut<NextState<ClimatePhase>>,
+    mut channel: Local<Option<Receiver<Result<(TectonicState, ClimateInit), u16>>>>,
 ) {
-    let ClimatePhase::TectSetup(step) = **state else {
+    let ClimatePhase::TectSetup(mut step) = **state else {
         unreachable!()
     };
     if step == 0 {
         debug!("Beginning tectonics setup");
     }
     trace!(step, "Tectonics setup");
-    let state = try_init_terrain(config.tectonics.depth, &mut init.rng);
-    if let Some(state) = state {
-        commands.insert_resource(TectonicData { state });
-        next_state.set(ClimatePhase::TectStep(0));
+    if let Some(rx) = &mut *channel {
+        match rx.try_iter().last() {
+            Some(Ok((state, init_))) => {
+                *init = init_;
+                commands.insert_resource(TectonicData { state });
+                next_state.set(ClimatePhase::TectStep(0));
+            }
+            Some(Err(step)) => next_state.set(ClimatePhase::TectSetup(step + 1)),
+            None => {}
+        }
     } else {
-        next_state.set(ClimatePhase::TectSetup(step + 1));
+        let depth = config.tectonics.depth;
+        let mut init = init.clone();
+        let (tx, rx) = crossbeam_channel::bounded(16);
+        *channel = Some(rx);
+        AsyncComputeTaskPool::get()
+            .spawn(async move {
+                loop {
+                    step += 1;
+                    #[allow(clippy::collapsible_else_if)]
+                    if let Some(state) = try_init_terrain(depth, &mut init.rng) {
+                        if let Err(_err) = tx.send(Ok((state, init))) {
+                            error!("Channel is closed!");
+                        }
+                        break;
+                    } else {
+                        if let Err(_err) = tx.send(Err(step)) {
+                            error!("Channel is closed!");
+                        }
+                    }
+                }
+            })
+            .detach();
     }
 }
 
@@ -305,12 +335,23 @@ pub(crate) fn run_climate(
     >,
     state: Res<State<ClimatePhase>>,
     mut next_state: ResMut<NextState<ClimatePhase>>,
+    mut channel: Local<Option<Receiver<(ClimateData, ClimateInit)>>>,
 ) {
     let ClimatePhase::ClimateStep(step) = **state else {
         unreachable!()
     };
     if step == 0 {
         debug!("Beginning climate simulation");
+    }
+    if let Some(rx) = &mut *channel {
+        if let Ok(data) = rx.try_recv() {
+            *channel = None;
+            *climate = data.0;
+            *init = data.1;
+            next_state.set(ClimatePhase::ClimateStep(step + 1));
+        } else {
+            return;
+        }
     }
     trace!(step, "Climate step");
     if step >= config.climate.init_steps {
@@ -323,22 +364,34 @@ pub(crate) fn run_climate(
             planet.transmute_lens_filtered().query(),
             Res::clone(&config),
         );
-        let planet_transform = planet.single().2;
-        step_climate(
-            &mut climate.cells,
-            |x, y| {
-                let (xsin, xcos) = x.sin_cos();
-                let (ysin, ycos) = y.sin_cos();
-                let point = Vec3::new(xcos * ycos, xsin * ycos, ysin);
-                let (_, rot, trans) = planet_transform.to_scale_rotation_translation();
-                config.climate.intensity
-                    * rot.mul_vec3(point).dot(-trans.normalize_or_zero()).max(0.0)
-            },
-            config.climate.time_step * dt,
-            &mut init.rng,
-        );
-        climate.update();
-        next_state.set(ClimatePhase::ClimateStep(step + 1));
+        let planet_transform = *planet.single().2;
+        let mut climate = climate.clone();
+        let time_scale = config.climate.time_step * dt;
+        let intensity = config.climate.intensity;
+        let mut init = init.clone();
+        let (tx, rx) = crossbeam_channel::bounded(1);
+        *channel = Some(rx);
+        AsyncComputeTaskPool::get()
+            .spawn(async move {
+                step_climate(
+                    &mut climate.cells,
+                    |x, y| {
+                        let (xsin, xcos) = x.sin_cos();
+                        let (ysin, ycos) = y.sin_cos();
+                        let point = Vec3::new(xcos * ycos, xsin * ycos, ysin);
+                        let (_, rot, trans) = planet_transform.to_scale_rotation_translation();
+                        intensity * rot.mul_vec3(point).dot(-trans.normalize_or_zero()).max(0.0)
+                    },
+                    time_scale,
+                    &mut init.rng,
+                );
+                std::future::ready(()).await;
+                climate.update();
+                if let Err(_err) = tx.send((climate, init)) {
+                    error!("Somehow this channel closed?");
+                }
+            })
+            .detach();
     }
 }
 

--- a/server/src/utils/mesh.rs
+++ b/server/src/utils/mesh.rs
@@ -1,4 +1,5 @@
 use bevy::math::{Vec2, Vec3, Vec3Swizzles};
+use bevy::utils::ConditionalSend;
 use std::cmp::Ordering;
 
 pub use factor_common::mesh::MeshData;
@@ -62,6 +63,69 @@ pub fn try_mesh_quad<E>(
             let b_basis = vb * scale * i.min(j) as f32;
             let vert = b_basis + basis + v0;
             vertices[idx] = vert.extend(height(MeshPoint { abs: vert, i, j })?).xzy();
+            uv[idx] = (vert + uv_add) * uv_scale;
+        }
+    }
+    Ok(MeshData {
+        vertices,
+        triangles,
+        uv,
+    })
+}
+
+/// Same as `try_mesh_quad` but it's async and breaks after each chunk. It doesn't actually have to wait at all, this is just so it's fairer when running on a thread pool.
+pub async fn async_try_mesh_quad<E>(
+    corners: [Vec2; 4],
+    depth: usize,
+    mut height: impl FnMut(MeshPoint) -> Result<f32, E> + ConditionalSend,
+) -> Result<MeshData, E> {
+    let len = depth + 1;
+    let nverts = len * len;
+    let (min_x, max_x, min_y, max_y) = corners.iter().fold(
+        (
+            f32::INFINITY,
+            f32::NEG_INFINITY,
+            f32::INFINITY,
+            f32::NEG_INFINITY,
+        ),
+        |(ix, ax, iy, ay), &Vec2 { x, y }| (ix.min(x), ax.max(x), iy.min(y), ay.max(y)),
+    );
+    let scale_x = (max_x - min_x).recip();
+    let scale_y = (max_y - min_y).recip();
+    let uv_add = Vec2::new(-min_x, -min_y);
+    let uv_scale = Vec2::new(scale_x, scale_y);
+    let mut vertices = vec![Vec3::NAN; nverts];
+    let mut uv = vec![Vec2::NAN; nverts];
+    let mut triangles = Vec::with_capacity(2 * nverts);
+    let [v0, v1, v2, v3] = corners;
+    let va = v1 - v0;
+    let vb = v2 - v0;
+    let vc = v3 - v0;
+    let scale = (depth as f32).recip();
+    for i in 0..len {
+        for j in 0..len {
+            let idx = i * len + j;
+            let basis = match i.cmp(&j) {
+                Ordering::Less => {
+                    triangles.extend_from_slice(&[
+                        [idx as u32, (idx - 1) as u32, (idx + len) as u32],
+                        [(idx - 1) as u32, (idx + len - 1) as u32, (idx + len) as u32],
+                    ]);
+                    va * scale * i.abs_diff(j) as f32
+                }
+                Ordering::Greater => {
+                    triangles.extend_from_slice(&[
+                        [idx as u32, (idx + 1) as u32, (idx - len) as u32],
+                        [(idx + 1) as u32, (idx - len + 1) as u32, (idx - len) as u32],
+                    ]);
+                    vc * scale * i.abs_diff(j) as f32
+                }
+                Ordering::Equal => Vec2::ZERO,
+            };
+            let b_basis = vb * scale * i.min(j) as f32;
+            let vert = b_basis + basis + v0;
+            vertices[idx] = vert.extend(height(MeshPoint { abs: vert, i, j })?).xzy();
+            std::future::ready(()).await; // add in breaks
             uv[idx] = (vert + uv_add) * uv_scale;
         }
     }


### PR DESCRIPTION
Creating a new chunk is currently very slow, and it blocks the event loop to run. With this change, it's instead sent to the `AsyncComputeTaskPool` so it can run outside of the main loop.