### PR TITLE
Fix the CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install system libraries
         run: sudo apt install -y libasound2-dev libudev-dev libwayland-dev
       - name: Install clippy
-        run: rustup component add clippy
+        run: rustup component add --toolchain nightly clippy
       - uses: actions/checkout@v4
       # - name: Run tests
       #   run: cargo test
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install clippy
-        run: rustup component add clippy
+        run: rustup component add --toolchain nightly clippy
       - name: Install WASM target
         run: rustup target add wasm32-unknown-unknown
       - name: Check with clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Install system libraries
         run: sudo apt install -y libasound2-dev libudev-dev libwayland-dev
+      - name: Install clippy
+        run: rustup component add clippy
       - uses: actions/checkout@v4
       # - name: Run tests
       #   run: cargo test
@@ -25,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install clippy
+        run: rustup component add clippy
       - name: Install WASM target
         run: rustup target add wasm32-unknown-unknown
       - name: Check with clippy


### PR DESCRIPTION
The CI fails because Clippy wasn't installed. This should fix that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Rust CI workflow to ensure Clippy is installed with the nightly toolchain for improved code checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->